### PR TITLE
Use .node-dev.json `ignore` prop

### DIFF
--- a/lib/cfg.js
+++ b/lib/cfg.js
@@ -29,7 +29,7 @@ module.exports = function (main, opts) {
     if (opts.notify === false) c.notify = false;
   }
   
-  var ignoreWatch = ([]).concat(opts && opts['ignore-watch'] || []);  
+  var ignoreWatch = ([]).concat(opts && opts['ignore-watch'] || []).concat(c.ignore || []);  
   ignoreWatch.length && console.log('Ignore watch:', ignoreWatch)
   var ignore = ignoreWatch.concat(ignoreWatch.map(resolvePath));  
   return {


### PR DESCRIPTION
Today, only way to ignore paths is by sending them as cli parameters. This can become a bit hard to maintain if many path are supposed to be ignored.

The doc says that `ts-node-env` supports the same options as `node-env`, but the `ignore` configuration (see https://github.com/fgnass/node-dev#ignore-paths) is not taken into account by `ts-node-env`.

This PR fixes that by appending the content of the `ignore` field to the list of `ignored-watch`parameters